### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "electron-builder": "^5.12.1",
     "electron-mocha": "^3.0.0",
     "fs-jetpack": "^0.9.0",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "4.0",
     "gulp-batch": "^1.0.5",
     "gulp-less": "^3.0.3",
     "gulp-plumber": "^1.1.0",


### PR DESCRIPTION
fixes the "Command failed: git checkout 4.0" error. gulp changed the tag from 4.0 to 4.0.0